### PR TITLE
store email error messages in govd error field

### DIFF
--- a/HubAgent/Contracts.cs
+++ b/HubAgent/Contracts.cs
@@ -18,6 +18,8 @@ namespace HubAgent
         internal int message_id;
         [DataMember]
         internal string status;
+        [DataMember]
+        internal string error_message;
     }
 
     [DataContract]

--- a/HubAgent/Program.cs
+++ b/HubAgent/Program.cs
@@ -26,7 +26,7 @@ namespace HubAgent
 
             // Ensure that dynamics is properly setup for our use case
             dynamics.EnsureGovdeliveryPublisher();
-            dynamics.EnsureEmailGovdeliveryField();
+            dynamics.EnsureGovdeliveryEmailFields();
             dynamics.EnsureEmailMetadata();
 
             // Retrieve and send emails that are in "Pending Send"

--- a/HubAgentTests/DynamicsClientTests.cs
+++ b/HubAgentTests/DynamicsClientTests.cs
@@ -35,6 +35,38 @@ namespace HubAgentTest
         }
 
         [TestMethod]
+        public void TestUpdateErrorMessage()
+        {
+            var service = new Mock<IOrganizationService>();
+            service.Setup(dyn => dyn.Execute(It.IsAny<UpdateRequest>()));
+
+            var client = new Mock<DynamicsClient>("http://blah.test.com", "someone", "password");
+            client.Setup(obj => obj.retrieveEntity(It.IsAny<RetrieveRequest>())).Returns(new Entity());
+            client.Setup(obj => obj.getService()).Returns(service.Object);
+
+            client.Object.UpdateErrorMessage("5cd54c07-3391-4bc0-a68e-911c2a38ed0e", "it did not go well");
+            service.Verify(dyn => dyn.Execute(It.IsAny<UpdateRequest>()));
+            client.Verify(obj => obj.retrieveEntity(It.IsAny<RetrieveRequest>()));
+            client.Verify(obj => obj.getService());
+        }
+
+        [TestMethod]
+        public void TestUpdateNullErrorMessage()
+        {
+            var service = new Mock<IOrganizationService>();
+            service.Setup(dyn => dyn.Execute(It.IsAny<UpdateRequest>()));
+
+            var client = new Mock<DynamicsClient>("http://blah.test.com", "someone", "password");
+            client.Setup(obj => obj.retrieveEntity(It.IsAny<RetrieveRequest>())).Returns(new Entity());
+            client.Setup(obj => obj.getService()).Returns(service.Object);
+
+            client.Object.UpdateErrorMessage("5cd54c07-3391-4bc0-a68e-911c2a38ed0e", null);
+            service.Verify(dyn => dyn.Execute(It.IsAny<UpdateRequest>()), Times.Never());
+            client.Verify(obj => obj.retrieveEntity(It.IsAny<RetrieveRequest>()), Times.Never());
+            client.Verify(obj => obj.getService(), Times.Never());
+        }
+
+        [TestMethod]
         public void TestEnsureEmailGovdeliveryFieldPreexistingField()
         {
             var service = new Mock<IOrganizationService>();
@@ -45,11 +77,12 @@ namespace HubAgentTest
 
             var attributes = new AttributeMetadata[]
                              {
-                                 new AttributeMetadata(){ LogicalName = "govd_id" }
+                                 new AttributeMetadata(){ LogicalName = "govd_id" },
+                                 new AttributeMetadata(){ LogicalName = "govd_error_message" }
                              };
             client.Setup(obj => obj.retrieveMetadataAttributes(It.IsAny<string>())).Returns(attributes);
 
-            client.Object.EnsureEmailGovdeliveryField();
+            client.Object.EnsureGovdeliveryEmailFields();
             client.Verify(obj => obj.retrieveMetadataAttributes(It.IsAny<string>()));
             service.Verify(dyn => dyn.Execute(It.IsAny<CreateAttributeRequest>()), Times.Never());
         }
@@ -66,9 +99,9 @@ namespace HubAgentTest
            var attributes = new AttributeMetadata[]{};
             client.Setup(obj => obj.retrieveMetadataAttributes(It.IsAny<string>())).Returns(attributes);
 
-            client.Object.EnsureEmailGovdeliveryField();
+            client.Object.EnsureGovdeliveryEmailFields();
             client.Verify(obj => obj.retrieveMetadataAttributes(It.IsAny<string>()));
-            service.Verify(dyn => dyn.Execute(It.IsAny<CreateAttributeRequest>()));
+            service.Verify(dyn => dyn.Execute(It.IsAny<CreateAttributeRequest>()), Times.Exactly(2));
         }
 
         [TestMethod]

--- a/HubAgentTests/HubAgentTests.csproj
+++ b/HubAgentTests/HubAgentTests.csproj
@@ -38,17 +38,68 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AntiXSSLibrary">
+      <HintPath>..\..\..\..\SDK\Bin\AntiXSSLibrary.dll</HintPath>
+    </Reference>
+    <Reference Include="CrmSvcUtil">
+      <HintPath>..\..\..\..\SDK\Bin\CrmSvcUtil.exe</HintPath>
+    </Reference>
+    <Reference Include="LoginControlTester">
+      <HintPath>..\..\..\..\SDK\Bin\LoginControlTester.exe</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Crm.Outlook.Sdk">
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Crm.Outlook.Sdk.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy">
-      <HintPath>..\..\..\..\..\SDK\Bin\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Crm.Tools.EmailProviders">
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Crm.Tools.EmailProviders.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Client">
-      <HintPath>..\..\..\..\..\SDK\Bin\Microsoft.Xrm.Client.dll</HintPath>
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Xrm.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Client.CodeGeneration">
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Xrm.Client.CodeGeneration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Portal">
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Xrm.Portal.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Portal.Files">
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Xrm.Portal.Files.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk">
-      <HintPath>..\..\..\..\..\SDK\Bin\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Xrm.Sdk.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Sdk.Deployment">
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Sdk.Workflow">
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Tooling.Connector">
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Tooling.CrmConnectControl">
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Xrm.Tooling.CrmConnectControl.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Tooling.CrmConnector.Powershell">
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Xrm.Tooling.CrmConnector.Powershell.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Tooling.PackageDeployment.Powershell">
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Xrm.Tooling.PackageDeployment.Powershell.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Tooling.Ui.Styles">
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Xrm.Tooling.Ui.Styles.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Tooling.WebResourceUtility">
+      <HintPath>..\..\..\..\SDK\Bin\Microsoft.Xrm.Tooling.WebResourceUtility.dll</HintPath>
     </Reference>
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.2.1506.2016\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="SolutionPackager">
+      <HintPath>..\..\..\..\SDK\Bin\SolutionPackager.exe</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
@@ -60,6 +111,9 @@
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml.Serialization" />
+    <Reference Include="WebsiteCopy">
+      <HintPath>..\..\..\..\SDK\Bin\WebsiteCopy.exe</HintPath>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/HubAgentTests/HubClientTests.cs
+++ b/HubAgentTests/HubClientTests.cs
@@ -124,7 +124,8 @@ namespace HubAgentTest
             {
                 name = "email_status",
                 external_id = "dyn54c07-3391-4bc0-a68e-911c2a38ed0e",
-                status = "failed"
+                status = "failed",
+                error_message = "something terrible happened"
             };
 
             Event invalid_event = new Event()
@@ -157,6 +158,7 @@ namespace HubAgentTest
             var mockClient = new Mock<IDynamicsClient>();
             mockClient.Setup(dyn => dyn.AssociateGovdeliveryEmail(It.IsAny<string>(), It.IsAny<string>()));
             mockClient.Setup(dyn => dyn.UpdateStatus(It.IsAny<string>(), It.IsAny<string>()));
+            mockClient.Setup(dyn => dyn.UpdateErrorMessage(It.IsAny<string>(), It.IsAny<string>()));
             mockClient.Setup(dyn => dyn.LookupEmailByGovdeliveryId(It.IsAny<string>())).Returns("5cd54c07-3391-4bc0-a68e-911c2a38ed0e");
             var hubClient = new HubClient("https://blah.test.com", "blah", mockClient.Object);
 
@@ -168,8 +170,11 @@ namespace HubAgentTest
             hubClient.UpdateEmailStatuses().Wait();
 
             mockClient.Verify(dyn => dyn.AssociateGovdeliveryEmail("23a4", "8080"));
+            mockClient.Verify(dyn => dyn.UpdateErrorMessage("23a4", ""));
             mockClient.Verify(dyn => dyn.UpdateStatus("5cd54c07-3391-4bc0-a68e-911c2a38ed0e","Sent"));
+            mockClient.Verify(dyn => dyn.UpdateErrorMessage("5cd54c07-3391-4bc0-a68e-911c2a38ed0e", null));
             mockClient.Verify(dyn => dyn.UpdateStatus(invalid_email_status_event.external_id, "Failed"));
+            mockClient.Verify(dyn => dyn.UpdateErrorMessage(invalid_email_status_event.external_id, invalid_email_status_event.error_message));
         }
 
         [TestMethod]


### PR DESCRIPTION
* on connect, add a custom email activity field for error messages if not already present
* on email_status error event, populate error message field
* when retrieving email_sent events, clear out error message if present (e.g. from a previous send failure)
